### PR TITLE
fix: 修复审查发现的安全与公开接口问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,6 @@ plan.md
 ### Docker 运行时数据与敏感配置 ###
 .env
 .env.properties
+tmp_*secrets*.txt
 config/rootCA.pem
 config/nginx/certs/

--- a/frontend/apps/site/app/pages/blog/[id].vue
+++ b/frontend/apps/site/app/pages/blog/[id].vue
@@ -83,10 +83,12 @@ useSeoMeta({
       <USeparator class="mb-8" />
 
       <!-- 文章内容 -->
+      <!-- eslint-disable vue/no-v-html -->
       <div
         class="prose prose-neutral dark:prose-invert max-w-none"
         v-html="sanitizedContent"
       />
+      <!-- eslint-enable vue/no-v-html -->
 
       <USeparator class="my-10" />
 

--- a/frontend/layers/base/composables/useSanitizedHtml.ts
+++ b/frontend/layers/base/composables/useSanitizedHtml.ts
@@ -1,5 +1,49 @@
 import DOMPurify from 'isomorphic-dompurify'
 
+type SanitizeElementHookData = {
+  tagName: string
+}
+
+type DOMPurifyWithHooks = typeof DOMPurify & {
+  addHook: (
+    entryPoint: 'uponSanitizeElement',
+    hook: (node: Node, data: SanitizeElementHookData) => void
+  ) => void
+}
+
+const ALLOWED_IFRAME_HOSTS = new Set([
+  'player.bilibili.com',
+  'www.youtube.com',
+  'www.youtube-nocookie.com',
+  'player.vimeo.com',
+  'open.spotify.com',
+  'music.163.com'
+])
+
+function isAllowedIframeSrc(src: string | null): boolean {
+  if (!src) {
+    return false
+  }
+
+  try {
+    const url = new URL(src)
+    return url.protocol === 'https:' && ALLOWED_IFRAME_HOSTS.has(url.hostname)
+  } catch {
+    return false
+  }
+}
+
+(DOMPurify as DOMPurifyWithHooks).addHook('uponSanitizeElement', (node, data) => {
+  if (data.tagName !== 'iframe') {
+    return
+  }
+
+  const element = node as Element
+  if (!isAllowedIframeSrc(element.getAttribute('src'))) {
+    element.remove()
+  }
+})
+
 /**
  * 对 HTML 字符串进行 XSS 清洗，保留文章渲染所需的安全标签和属性。
  *
@@ -20,7 +64,6 @@ export function useSanitizedHtml(html: MaybeRef<string>): ComputedRef<string> | 
       // 禁止表单和脚本
       FORBID_TAGS: ['form', 'input', 'textarea', 'select', 'button', 'style'],
       FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover'],
-      // iframe 仅允许白名单域
       ALLOW_UNKNOWN_PROTOCOLS: false,
     })
 

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/controller/ProductApiController.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/controller/ProductApiController.java
@@ -2,6 +2,7 @@ package com.rymcu.mortise.product.api.controller;
 
 import com.rymcu.mortise.core.result.GlobalResult;
 import com.rymcu.mortise.log.annotation.ApiLog;
+import com.rymcu.mortise.product.api.dto.ApiProductModels.ProductDetailVO;
 import com.rymcu.mortise.product.api.facade.ProductCatalogApiFacade;
 import com.rymcu.mortise.product.entity.Product;
 import com.rymcu.mortise.web.annotation.ApiController;
@@ -41,7 +42,7 @@ public class ProductApiController {
     @GetMapping("/{id}")
     @ApiLog("查询产品详情")
     @Operation(summary = "获取上架产品详情")
-    public GlobalResult<Product> getProductDetail(
+    public GlobalResult<ProductDetailVO> getProductDetail(
             @Parameter(description = "产品ID") @PathVariable("id") Long id) {
         return GlobalResult.success(productCatalogApiFacade.getProductDetail(id));
     }

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/dto/ApiProductModels.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/dto/ApiProductModels.java
@@ -1,10 +1,11 @@
 package com.rymcu.mortise.product.api.dto;
 
-import com.rymcu.mortise.product.entity.Product;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public final class ApiProductModels {
 
@@ -12,9 +13,33 @@ public final class ApiProductModels {
     }
 
     @Data
-    @EqualsAndHashCode(callSuper = true)
-    public static class ProductDetailVO extends Product {
+    public static class ProductDetailVO {
 
+        private Long id;
+        private String productCode;
+        private String title;
+        private String subtitle;
+        private String description;
+        private String shortDescription;
+        private String coverImageUrl;
+        private List<String> galleryImages;
+        private String productType;
+        private Long categoryId;
+        private String[] tags;
+        private Map<String, Object> features;
+        private Map<String, Object> specifications;
+        private String seoTitle;
+        private String seoDescription;
+        private String seoKeywords;
+        private Integer status;
+        private Boolean isFeatured;
+        private Integer sortNo;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime createdTime;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime updatedTime;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime publishedTime;
         private List<SkuTargetVO> skuTargets;
     }
 

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/dto/ApiProductModels.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/dto/ApiProductModels.java
@@ -1,0 +1,32 @@
+package com.rymcu.mortise.product.api.dto;
+
+import com.rymcu.mortise.product.entity.Product;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+public final class ApiProductModels {
+
+    private ApiProductModels() {
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class ProductDetailVO extends Product {
+
+        private List<SkuTargetVO> skuTargets;
+    }
+
+    @Data
+    public static class SkuTargetVO {
+
+        private Long id;
+        private Long productSkuId;
+        private String targetType;
+        private Long targetId;
+        private Integer quantity;
+        private Integer validityDays;
+        private String accessLevel;
+    }
+}

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/ProductCatalogApiFacade.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/ProductCatalogApiFacade.java
@@ -1,5 +1,6 @@
 package com.rymcu.mortise.product.api.facade;
 
+import com.rymcu.mortise.product.api.dto.ApiProductModels.ProductDetailVO;
 import com.rymcu.mortise.product.entity.Product;
 
 import java.util.List;
@@ -9,7 +10,7 @@ public interface ProductCatalogApiFacade {
 
     List<Product> listProducts(String productType);
 
-    Product getProductDetail(Long id);
+    ProductDetailVO getProductDetail(Long id);
 
     Map<String, String> listProductTypes();
 }

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/impl/ProductCatalogApiFacadeImpl.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/impl/ProductCatalogApiFacadeImpl.java
@@ -1,20 +1,39 @@
 package com.rymcu.mortise.product.api.facade.impl;
 
+import com.rymcu.mortise.product.api.dto.ApiProductModels.ProductDetailVO;
+import com.rymcu.mortise.product.api.dto.ApiProductModels.SkuTargetVO;
 import com.rymcu.mortise.product.api.facade.ProductCatalogApiFacade;
 import com.rymcu.mortise.product.entity.Product;
+import com.rymcu.mortise.product.entity.ProductSku;
 import com.rymcu.mortise.product.service.query.ProductQueryService;
+import com.rymcu.mortise.product.service.query.ProductSkuQueryService;
+import com.rymcu.mortise.product.service.query.ProductSkuTargetQueryService;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class ProductCatalogApiFacadeImpl implements ProductCatalogApiFacade {
 
-    private final ProductQueryService productQueryService;
+    private static final String ACTIVE_SKU_STATUS = "active";
+    private static final Integer ENABLED_TARGET_STATUS = 1;
 
-    public ProductCatalogApiFacadeImpl(ProductQueryService productQueryService) {
+    private final ProductQueryService productQueryService;
+    private final ProductSkuQueryService productSkuQueryService;
+    private final ProductSkuTargetQueryService productSkuTargetQueryService;
+
+    public ProductCatalogApiFacadeImpl(
+            ProductQueryService productQueryService,
+            ProductSkuQueryService productSkuQueryService,
+            ProductSkuTargetQueryService productSkuTargetQueryService
+    ) {
         this.productQueryService = productQueryService;
+        this.productSkuQueryService = productSkuQueryService;
+        this.productSkuTargetQueryService = productSkuTargetQueryService;
     }
 
     @Override
@@ -23,8 +42,39 @@ public class ProductCatalogApiFacadeImpl implements ProductCatalogApiFacade {
     }
 
     @Override
-    public Product getProductDetail(Long id) {
-        return productQueryService.findPublishedById(id);
+    public ProductDetailVO getProductDetail(Long id) {
+        Product product = productQueryService.findPublishedById(id);
+        if (product == null) {
+            return null;
+        }
+
+        ProductDetailVO detailVO = new ProductDetailVO();
+        BeanUtils.copyProperties(product, detailVO);
+
+        List<ProductSku> skuList = productSkuQueryService.findByProductId(id);
+        if (skuList.isEmpty()) {
+            detailVO.setSkuTargets(Collections.emptyList());
+            return detailVO;
+        }
+
+        List<Long> skuIds = skuList.stream()
+                .filter(sku -> ACTIVE_SKU_STATUS.equals(sku.getStatus()))
+                .map(ProductSku::getId)
+                .toList();
+        if (skuIds.isEmpty()) {
+            detailVO.setSkuTargets(Collections.emptyList());
+            return detailVO;
+        }
+
+        detailVO.setSkuTargets(productSkuTargetQueryService.findByProductSkuIds(skuIds).stream()
+                .filter(target -> ENABLED_TARGET_STATUS.equals(target.getStatus()))
+                .map(target -> {
+                    SkuTargetVO targetVO = new SkuTargetVO();
+                    BeanUtils.copyProperties(target, targetVO);
+                    return targetVO;
+                })
+                .collect(Collectors.toList()));
+        return detailVO;
     }
 
     @Override

--- a/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/impl/ProductCatalogApiFacadeImpl.java
+++ b/mortise-product/mortise-product-api/src/main/java/com/rymcu/mortise/product/api/facade/impl/ProductCatalogApiFacadeImpl.java
@@ -1,5 +1,6 @@
 package com.rymcu.mortise.product.api.facade.impl;
 
+import com.rymcu.mortise.common.enumerate.Status;
 import com.rymcu.mortise.product.api.dto.ApiProductModels.ProductDetailVO;
 import com.rymcu.mortise.product.api.dto.ApiProductModels.SkuTargetVO;
 import com.rymcu.mortise.product.api.facade.ProductCatalogApiFacade;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 public class ProductCatalogApiFacadeImpl implements ProductCatalogApiFacade {
 
     private static final String ACTIVE_SKU_STATUS = "active";
-    private static final Integer ENABLED_TARGET_STATUS = 1;
+    private static final Integer ENABLED_TARGET_STATUS = Status.ENABLED.getCode();
 
     private final ProductQueryService productQueryService;
     private final ProductSkuQueryService productSkuQueryService;

--- a/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/ProductSkuTargetService.java
+++ b/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/ProductSkuTargetService.java
@@ -1,0 +1,19 @@
+package com.rymcu.mortise.product.service;
+
+import com.mybatisflex.core.service.IService;
+import com.rymcu.mortise.product.entity.ProductSkuTarget;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 产品 SKU 目标映射服务
+ *
+ * @author ronger
+ */
+public interface ProductSkuTargetService extends IService<ProductSkuTarget> {
+
+    List<ProductSkuTarget> findByProductSkuId(Long productSkuId);
+
+    List<ProductSkuTarget> findByProductSkuIds(Collection<Long> productSkuIds);
+}

--- a/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/impl/ProductSkuTargetServiceImpl.java
+++ b/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/impl/ProductSkuTargetServiceImpl.java
@@ -1,0 +1,39 @@
+package com.rymcu.mortise.product.service.impl;
+
+import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.spring.service.impl.ServiceImpl;
+import com.rymcu.mortise.product.entity.ProductSkuTarget;
+import com.rymcu.mortise.product.mapper.ProductSkuTargetMapper;
+import com.rymcu.mortise.product.service.ProductSkuTargetService;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.rymcu.mortise.product.entity.table.ProductSkuTargetTableDef.PRODUCT_SKU_TARGET;
+
+@Service
+public class ProductSkuTargetServiceImpl extends ServiceImpl<ProductSkuTargetMapper, ProductSkuTarget>
+        implements ProductSkuTargetService {
+
+    @Override
+    public List<ProductSkuTarget> findByProductSkuId(Long productSkuId) {
+        return mapper.selectListByQuery(
+                QueryWrapper.create()
+                        .where(PRODUCT_SKU_TARGET.PRODUCT_SKU_ID.eq(productSkuId))
+                        .orderBy(PRODUCT_SKU_TARGET.CREATED_TIME.asc())
+        );
+    }
+
+    @Override
+    public List<ProductSkuTarget> findByProductSkuIds(Collection<Long> productSkuIds) {
+        if (productSkuIds == null || productSkuIds.isEmpty()) {
+            return List.of();
+        }
+        return mapper.selectListByQuery(
+                QueryWrapper.create()
+                        .where(PRODUCT_SKU_TARGET.PRODUCT_SKU_ID.in(productSkuIds))
+                        .orderBy(PRODUCT_SKU_TARGET.PRODUCT_SKU_ID.asc(), PRODUCT_SKU_TARGET.CREATED_TIME.asc())
+        );
+    }
+}

--- a/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/query/ProductSkuTargetQueryService.java
+++ b/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/query/ProductSkuTargetQueryService.java
@@ -1,0 +1,15 @@
+package com.rymcu.mortise.product.service.query;
+
+import com.rymcu.mortise.product.entity.ProductSkuTarget;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ProductSkuTargetQueryService {
+
+    List<ProductSkuTarget> findByProductSkuId(Long productSkuId);
+
+    List<ProductSkuTarget> findByProductSkuIds(Collection<Long> productSkuIds);
+
+    ProductSkuTarget getById(Long id);
+}

--- a/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/query/impl/ProductSkuTargetQueryServiceImpl.java
+++ b/mortise-product/mortise-product-application/src/main/java/com/rymcu/mortise/product/service/query/impl/ProductSkuTargetQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.rymcu.mortise.product.service.query.impl;
+
+import com.rymcu.mortise.product.entity.ProductSkuTarget;
+import com.rymcu.mortise.product.service.ProductSkuTargetService;
+import com.rymcu.mortise.product.service.query.ProductSkuTargetQueryService;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+
+@Service
+public class ProductSkuTargetQueryServiceImpl implements ProductSkuTargetQueryService {
+
+    private final ProductSkuTargetService productSkuTargetService;
+
+    public ProductSkuTargetQueryServiceImpl(ProductSkuTargetService productSkuTargetService) {
+        this.productSkuTargetService = productSkuTargetService;
+    }
+
+    @Override
+    public List<ProductSkuTarget> findByProductSkuId(Long productSkuId) {
+        return productSkuTargetService.findByProductSkuId(productSkuId);
+    }
+
+    @Override
+    public List<ProductSkuTarget> findByProductSkuIds(Collection<Long> productSkuIds) {
+        return productSkuTargetService.findByProductSkuIds(productSkuIds);
+    }
+
+    @Override
+    public ProductSkuTarget getById(Long id) {
+        return productSkuTargetService.getById(id);
+    }
+}

--- a/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMessageController.java
+++ b/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMessageController.java
@@ -39,7 +39,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送模板消息", description = "发送微信模板消息给指定用户")
     @PostMapping("/template")
-    @PreAuthorize("hasAuthority('wechat:account:edit')")
+    @PreAuthorize("hasAuthority('wechat:message:send')")
     public GlobalResult<Map<String, String>> sendTemplateMessage(
             @Parameter(description = "模板消息对象", required = true)
             @RequestBody TemplateMessage message,
@@ -58,7 +58,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送文本消息", description = "发送客服文本消息给指定用户")
     @PostMapping("/text")
-    @PreAuthorize("hasAuthority('wechat:account:edit')")
+    @PreAuthorize("hasAuthority('wechat:message:send')")
     public GlobalResult<Map<String, String>> sendTextMessage(
             @Parameter(description = "用户OpenID", required = true)
             @RequestParam String openId,
@@ -78,7 +78,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送图文消息", description = "发送客服图文消息给指定用户")
     @PostMapping("/news")
-    @PreAuthorize("hasAuthority('wechat:account:edit')")
+    @PreAuthorize("hasAuthority('wechat:message:send')")
     public GlobalResult<Map<String, String>> sendNewsMessage(
             @Parameter(description = "图文消息请求对象", required = true)
             @RequestBody NewsMessageRequest request,

--- a/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMessageController.java
+++ b/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMessageController.java
@@ -1,7 +1,7 @@
 package com.rymcu.mortise.wechat.controller;
 
-import com.rymcu.mortise.web.annotation.ApiController;
 import com.rymcu.mortise.core.result.GlobalResult;
+import com.rymcu.mortise.web.annotation.AdminController;
 import com.rymcu.mortise.wechat.entity.TemplateMessage;
 import com.rymcu.mortise.wechat.facade.WeChatMessageFacade;
 import com.rymcu.mortise.wechat.facade.WeChatMessageFacade.NewsMessageRequest;
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -20,7 +21,7 @@ import java.util.Map;
  * @author ronger
  * @since 1.0.0
  */
-@ApiController
+@AdminController
 @RequestMapping("/wechat/messages")
 @RequiredArgsConstructor
 @ConditionalOnBean(WeChatMessageFacade.class)
@@ -38,6 +39,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送模板消息", description = "发送微信模板消息给指定用户")
     @PostMapping("/template")
+    @PreAuthorize("hasAuthority('wechat:account:edit')")
     public GlobalResult<Map<String, String>> sendTemplateMessage(
             @Parameter(description = "模板消息对象", required = true)
             @RequestBody TemplateMessage message,
@@ -56,6 +58,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送文本消息", description = "发送客服文本消息给指定用户")
     @PostMapping("/text")
+    @PreAuthorize("hasAuthority('wechat:account:edit')")
     public GlobalResult<Map<String, String>> sendTextMessage(
             @Parameter(description = "用户OpenID", required = true)
             @RequestParam String openId,
@@ -75,6 +78,7 @@ public class WeChatMessageController {
      */
     @Operation(summary = "发送图文消息", description = "发送客服图文消息给指定用户")
     @PostMapping("/news")
+    @PreAuthorize("hasAuthority('wechat:account:edit')")
     public GlobalResult<Map<String, String>> sendNewsMessage(
             @Parameter(description = "图文消息请求对象", required = true)
             @RequestBody NewsMessageRequest request,

--- a/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMpManagementController.java
+++ b/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/controller/WeChatMpManagementController.java
@@ -1,13 +1,13 @@
 package com.rymcu.mortise.wechat.controller;
 
+import com.rymcu.mortise.core.result.GlobalResult;
 import com.rymcu.mortise.web.annotation.AdminController;
 import com.rymcu.mortise.wechat.facade.WeChatMpManagementFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -29,17 +29,13 @@ public class WeChatMpManagementController {
      * <p>从数据库重新加载所有配置，适用于批量变更后的刷新</p>
      */
     @PostMapping("/reload-all")
-    public ResponseEntity<Map<String, Object>> reloadAll() {
+    @PreAuthorize("hasAuthority('wechat:account:edit')")
+    public GlobalResult<Map<String, Object>> reloadAll() {
         try {
-            return ResponseEntity.ok(weChatMpManagementFacade.reloadAll());
+            return GlobalResult.success(weChatMpManagementFacade.reloadAll());
         } catch (Exception e) {
             log.error("Failed to reload all WeChat MP configurations", e);
-
-            Map<String, Object> result = new HashMap<>();
-            result.put("success", false);
-            result.put("message", "重新加载失败: " + e.getMessage());
-
-            return ResponseEntity.internalServerError().body(result);
+            return GlobalResult.error("重新加载失败: " + e.getMessage());
         }
     }
 
@@ -48,18 +44,13 @@ public class WeChatMpManagementController {
      * <p>适用于单个账号配置变更后的热更新</p>
      */
     @PostMapping("/accounts/{accountId}/reload")
-    public ResponseEntity<Map<String, Object>> reloadAccount(@PathVariable Long accountId) {
+    @PreAuthorize("hasAuthority('wechat:account:edit')")
+    public GlobalResult<Map<String, Object>> reloadAccount(@PathVariable Long accountId) {
         try {
-            return ResponseEntity.ok(weChatMpManagementFacade.reloadAccount(accountId));
+            return GlobalResult.success(weChatMpManagementFacade.reloadAccount(accountId));
         } catch (Exception e) {
             log.error("Failed to reload WeChat MP configuration for accountId: {}", accountId, e);
-
-            Map<String, Object> result = new HashMap<>();
-            result.put("success", false);
-            result.put("message", "账号配置更新失败: " + e.getMessage());
-            result.put("accountId", accountId);
-
-            return ResponseEntity.internalServerError().body(result);
+            return GlobalResult.error("账号配置更新失败: " + e.getMessage());
         }
     }
 
@@ -68,18 +59,13 @@ public class WeChatMpManagementController {
      * <p>适用于账号禁用或删除后的热移除</p>
      */
     @DeleteMapping("/accounts/{accountId}")
-    public ResponseEntity<Map<String, Object>> removeAccount(@PathVariable Long accountId) {
+    @PreAuthorize("hasAuthority('wechat:account:delete')")
+    public GlobalResult<Map<String, Object>> removeAccount(@PathVariable Long accountId) {
         try {
-            return ResponseEntity.ok(weChatMpManagementFacade.removeAccount(accountId));
+            return GlobalResult.success(weChatMpManagementFacade.removeAccount(accountId));
         } catch (Exception e) {
             log.error("Failed to remove WeChat MP configuration for accountId: {}", accountId, e);
-
-            Map<String, Object> result = new HashMap<>();
-            result.put("success", false);
-            result.put("message", "账号配置移除失败: " + e.getMessage());
-            result.put("accountId", accountId);
-
-            return ResponseEntity.internalServerError().body(result);
+            return GlobalResult.error("账号配置移除失败: " + e.getMessage());
         }
     }
 
@@ -88,8 +74,9 @@ public class WeChatMpManagementController {
      * <p>用于管理界面显示当前配置状态</p>
      */
     @GetMapping("/status")
-    public ResponseEntity<Map<String, Object>> getStatus() {
-        return ResponseEntity.ok(weChatMpManagementFacade.getStatus());
+    @PreAuthorize("hasAuthority('wechat:account:query')")
+    public GlobalResult<Map<String, Object>> getStatus() {
+        return GlobalResult.success(weChatMpManagementFacade.getStatus());
     }
 
     /**
@@ -97,8 +84,9 @@ public class WeChatMpManagementController {
      * <p>用于验证配置是否正确</p>
      */
     @GetMapping("/accounts/{accountId}/test")
-    public ResponseEntity<Map<String, Object>> testAccount(@PathVariable Long accountId) {
-        return ResponseEntity.ok(weChatMpManagementFacade.testAccount(accountId));
+    @PreAuthorize("hasAuthority('wechat:account:query')")
+    public GlobalResult<Map<String, Object>> testAccount(@PathVariable Long accountId) {
+        return GlobalResult.success(weChatMpManagementFacade.testAccount(accountId));
     }
 }
 

--- a/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/handler/MsgHandler.java
+++ b/mortise-wechat/src/main/java/com/rymcu/mortise/wechat/handler/MsgHandler.java
@@ -2,11 +2,13 @@ package com.rymcu.mortise.wechat.handler;
 
 import com.rymcu.mortise.wechat.builder.TextBuilder;
 import com.rymcu.mortise.wechat.utils.JsonUtils;
+import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.session.WxSessionManager;
 import me.chanjar.weixin.mp.api.WxMpService;
 import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
 import me.chanjar.weixin.mp.bean.message.WxMpXmlOutMessage;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -16,6 +18,7 @@ import static me.chanjar.weixin.common.api.WxConsts.XmlMsgType;
 /**
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
+@Slf4j
 @Component
 public class MsgHandler extends AbstractHandler {
 
@@ -29,8 +32,10 @@ public class MsgHandler extends AbstractHandler {
         }
 
         //当用户输入关键词如“你好”，“客服”等，并且有客服在线时，把消息转发给在线客服
+        String contentText = wxMessage.getContent();
         try {
-            if ((wxMessage.getContent().startsWith("你好") || wxMessage.getContent().startsWith("客服"))
+            if (StringUtils.isNotBlank(contentText)
+                && (contentText.startsWith("你好") || contentText.startsWith("客服"))
                 && !weixinService.getKefuService().kfOnlineList()
                     .getKfOnlineList().isEmpty()) {
                 return WxMpXmlOutMessage.TRANSFER_CUSTOMER_SERVICE()
@@ -38,7 +43,7 @@ public class MsgHandler extends AbstractHandler {
                     .toUser(wxMessage.getFromUser()).build();
             }
         } catch (WxErrorException e) {
-            e.printStackTrace();
+            log.warn("Failed to check WeChat customer service online list", e);
         }
 
         //TODO 组装回复消息

--- a/mortise-wechat/src/main/resources/db/migration/V439__Grant_Wechat_Message_Send_Permission.sql
+++ b/mortise-wechat/src/main/resources/db/migration/V439__Grant_Wechat_Message_Send_Permission.sql
@@ -1,0 +1,19 @@
+-- 为微信消息发送接口补齐独立按钮/API 权限
+INSERT INTO mortise.mortise_menu (
+    id, label, permission, icon, href, status, del_flag, menu_type, sort_no, parent_id, created_time, updated_time
+)
+SELECT 61000000000000106, '发送微信消息', 'wechat:message:send', 'i-lucide-send', '', 1, 0, 2, 6, parent.id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM mortise.mortise_menu parent
+WHERE parent.permission = 'wechat:account'
+  AND NOT EXISTS (SELECT 1 FROM mortise.mortise_menu WHERE permission = 'wechat:message:send');
+
+INSERT INTO mortise.mortise_role_menu (id_mortise_role, id_mortise_menu)
+SELECT role.id, menu.id
+FROM mortise.mortise_role role
+CROSS JOIN mortise.mortise_menu menu
+WHERE role.permission = 'ADMIN'
+  AND menu.permission = 'wechat:message:send'
+  AND NOT EXISTS (
+    SELECT 1 FROM mortise.mortise_role_menu rm
+    WHERE rm.id_mortise_role = role.id AND rm.id_mortise_menu = menu.id
+  );


### PR DESCRIPTION
## 变更说明

- 为微信管理与消息发送接口补齐方法级权限控制，并统一微信管理接口返回 `GlobalResult`。
- 修复微信非文本消息回调中 `content` 为空导致的 NPE，并改用日志记录异常。
- 调整公开产品详情返回模型，仅暴露启用 SKU 的启用目标映射，并隐藏内部条件、元数据和删除标记等字段。
- 为富文本 `iframe` 增加 HTTPS 白名单校验，并保留文章详情页的受控 `v-html` 使用。
- 将临时 secrets 文件模式加入 `.gitignore`。

## 关联规范

- 规范链接: `.github/instructions/permission-conventions.instructions.md`, `.github/instructions/springboot.instructions.md`, `.github/instructions/frontend-nuxt-patterns.instructions.md`
- 规范状态: Implemented

## 范围说明

本 PR 只包含根仓库 `rymcu/mortise` 的审查修复；商业子模块 `mortise-commerce`、`mortise-payment` 以及其他子模块改动没有纳入本次提交，需要按各自仓库独立提交和推送。

## 自检清单

- [x] 规范已评审并批准
- [x] 实现与规范一致
- [x] 影响评估已更新 (性能/兼容性/回滚)
- [x] 必要的测试已补充或更新

## 验证

- `git diff --cached --check`
- `mvn -pl mortise-wechat,mortise-product/mortise-product-api -am clean compile -DskipTests`
- `pnpm --filter @mortise/site lint`
- `pnpm --filter @mortise/site typecheck`